### PR TITLE
Remove "p_" from mailadresses, change subject on lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,11 @@ More details about the sync workflow can be found in SyncWorkflow.md
    - `LINUXMUSTER_MAILCOW_DOMAIN_QUOTA` - total quota of one domain. CAUTION! If this is not enough to fit all mailboxes the import will fail!!
    - `LINUXMUSTER_MAILCOW_ENABLE_GAL` - whether to enable the global addressbook
    - **Optional** Only use these if you know what you are doing! They are not required for normal operation!
-     - `LDAP-MAILCOW_API_URI` - mailcow API uri.
+     - `LINUXMUSTER_MAILCOW_API_URI` - mailcow API uri.
      - `LINUXMUSTER_MAILCOW_DOCKERAPI_URI` - dockerapi API uri.
+     - `LINUXMUSTER_MAILCOW_LDAP_USER_FILTER` - users that get mail accounts, default is teachers and students, set to `"(sophomorixRole=teacher)"` to restrict to teachers
+     - `LINUXMUSTER_MAILCOW_LDAP_SOGO_USER_FILTER` - users that are allowed to use SOGo, defaults to teachers or students, set to `"(sophomorixRole='teacher')"` to restrict to teachers
+
 
 4. Start additional container: `docker compose up -d linuxmuster-mailcow`
 5. Check logs `docker compose logs -f linuxmuster-mailcow` (quit with ctrl+c). Please note: Connection errors are normal after all containers are started with `docker compose up -d`.

--- a/src/ldapHelper.py
+++ b/src/ldapHelper.py
@@ -9,6 +9,8 @@ class LdapHelper:
 
     def bind(self):
         try:
+            # uncomment to disable CERT-Check on LDAP-Server
+            #ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
             self._ldapConnection = ldap.initialize(f"{self._uri}")
             self._ldapConnection.set_option(ldap.OPT_REFERRALS, 0)
             self._ldapConnection.simple_bind_s(self._bindDn, self._bindPassword)

--- a/src/syncer.py
+++ b/src/syncer.py
@@ -20,10 +20,8 @@ coloredlogs.install(
 
 class LinuxmusterMailcowSyncer:
 
-    #ldapSogoUserFilter = "(sophomorixRole='student' OR sophomorixRole='teacher')"
-    ldapSogoUserFilter = "( sophomorixRole='teacher')"
-    #ldapUserFilter = "(|(sophomorixRole=student)(sophomorixRole=teacher))"
-    ldapUserFilter = "(sophomorixRole=teacher)"
+    ldapSogoUserFilter = "(sophomorixRole='student' OR sophomorixRole='teacher')"
+    ldapUserFilter = "(|(sophomorixRole=student)(sophomorixRole=teacher))"
     ldapMailingListFilter = "(|(sophomorixType=adminclass)(sophomorixType=project))"
     ldapMailingListMemberFilter = f"(&(memberof:1.2.840.113556.1.4.1941:=@@mailingListDn@@){ldapUserFilter})"
 
@@ -80,7 +78,7 @@ class LinuxmusterMailcowSyncer:
         logging.info("    * Loading groups from AD")
         ret, adLists = self._ldap.search(
             self.ldapMailingListFilter,
-            ["mail", "proxyAddresses", "distinguishedName",
+            ["mail", "proxyAddresses", "distinguishedName", "description",
                 "sophomorixMailList", "sAMAccountName"]
         )
 
@@ -135,7 +133,8 @@ class LinuxmusterMailcowSyncer:
                 continue
 
             mail = mailingList["mail"]
-            mail = mail[2:] if mail.startswith("p_")
+            if mail.startswith("p_"):
+                mail = mail[2:]
             desc = mailingList["description"]
             maildomain = mail.split("@")[-1]
             ret, members = self._ldap.search(
@@ -282,7 +281,6 @@ class LinuxmusterMailcowSyncer:
         for memberAddress in memberAddresses:
             scriptData += f"redirect :copy \"{memberAddress}\";\r\n"
         scriptData += "\r\ndiscard;stop;"
-        print(scriptData)
         mailcowFilters.addElement({
             'active': 1,
             'username': listAddress,
@@ -304,6 +302,8 @@ class LinuxmusterMailcowSyncer:
         ]
 
         allowedConfigKeys = [
+            "LINUXMUSTER_MAILCOW_LDAP_SOGO_USER_FILTER",
+            "LINUXMUSTER_MAILCOW_LDAP_USER_FILTER",
             "LINUXMUSTER_MAILCOW_DOCKERAPI_URI",
             "LINUXMUSTER_MAILCOW_API_URI"
         ]


### PR DESCRIPTION
- when the project account is created, remove the leading "p_" from LMN-name.
- when the maillist account is created, the name of the maillist is now "Verteiler name". ok this is opionated and german...
- when the mail goes to a maillist, change the subject from "oldsubject" to "[name] oldsubject"
- add possibility to set the ldap_filter for account creation and the sogo filter as environmental variables
- add possibility to hardcode an not-verifying SSL-Keys